### PR TITLE
CD-8286 | Enable Configurable Cross-File Analysis in IDE Extension

### DIFF
--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientInputFile.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientInputFile.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.util.List;
 import javax.annotation.CheckForNull;
 import org.sonarsource.sonarlint.core.commons.Language;
 
@@ -86,4 +87,12 @@ public interface ClientInputFile {
    */
   URI uri();
 
+  /**
+   * Dependency files of this file. If not null, files contain at least one usage of a method defined in this file.
+   *
+   * @return the dependency files, or {@code null} if none
+   */
+  default List<ClientInputFile> getDependencyFiles() {
+    return null;
+  }
 }

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientInputFile.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientInputFile.java
@@ -88,11 +88,11 @@ public interface ClientInputFile {
   URI uri();
 
   /**
-   * Dependency files of this file. If not null, files contain at least one usage of a method defined in this file.
+   * Reference files of this file. If not null, files contain at least one usage of a method defined in this file.
    *
-   * @return the dependency files, or {@code null} if none
+   * @return the Reference files, or {@code null} if none
    */
-  default List<ClientInputFile> getDependencyFiles() {
+  default List<ClientInputFile> getReferenceFiles() {
     return null;
   }
 }

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
@@ -53,7 +53,7 @@ public class InputFileBuilder {
         throw new IllegalStateException("Failed to open a stream on file: " + f.uri(), e);
       }
       return fileMetadata.readMetadata(stream, charset != null ? charset : Charset.defaultCharset(), f.uri(), exclusionsScanner.createCharHandlerFor(f));
-    }, buildDependencyInputFiles(inputFile));
+    }, buildReferenceInputFiles(inputFile));
     defaultInputFile.setType(inputFile.isTest() ? Type.TEST : Type.MAIN);
     var fileLanguage = inputFile.language();
     if (fileLanguage != null) {
@@ -66,26 +66,26 @@ public class InputFileBuilder {
     return defaultInputFile;
   }
 
-  private List<InputFile> buildDependencyInputFiles(ClientInputFile inputFile) {
-    List<ClientInputFile> dependencyFiles = inputFile.getReferenceFiles();
-    if (dependencyFiles == null) return null;
+  private List<InputFile> buildReferenceInputFiles(ClientInputFile inputFile) {
+    List<ClientInputFile> referenceFiles = inputFile.getReferenceFiles();
+    if (referenceFiles == null) return null;
 
     List<InputFile> result = new LinkedList<>();
-    for (var dependencyFile : dependencyFiles) {
-      result.add(toSonarLintInputFile(dependencyFile, inputFile));
+    for (var referenceFile : referenceFiles) {
+      result.add(toSonarLintInputFile(referenceFile, inputFile));
     }
     return result;
   }
 
-  private SonarLintInputFile toSonarLintInputFile(ClientInputFile dependencyFile, ClientInputFile parentFile) {
-    return new SonarLintInputFile(dependencyFile, f -> {
-      LOG.debug("Initializing metadata of dependency file {} for {}", f.uri(), parentFile.uri());
+  private SonarLintInputFile toSonarLintInputFile(ClientInputFile referenceFile, ClientInputFile parentFile) {
+    return new SonarLintInputFile(referenceFile, f -> {
+      LOG.debug("Initializing metadata of reference file {} for {}", f.uri(), parentFile.uri());
       try {
         var charset = f.charset();
         return fileMetadata.readMetadata(f.inputStream(), charset != null ? charset : Charset.defaultCharset(),
                   f.uri(), exclusionsScanner.createCharHandlerFor(f));
       } catch (IOException e) {
-        throw new IllegalStateException("Failed to open stream for dependency file: " + f.uri(), e);
+        throw new IllegalStateException("Failed to open stream for reference file: " + f.uri(), e);
       }
     });
   }

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
@@ -22,6 +22,9 @@ package org.sonarsource.sonarlint.core.analysis.container.analysis.filesystem;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.LinkedList;
+import java.util.List;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonarsource.sonarlint.core.analysis.api.ClientInputFile;
 import org.sonarsource.sonarlint.core.analysis.container.analysis.issue.ignore.scanner.IssueExclusionsLoader;
@@ -50,7 +53,7 @@ public class InputFileBuilder {
         throw new IllegalStateException("Failed to open a stream on file: " + f.uri(), e);
       }
       return fileMetadata.readMetadata(stream, charset != null ? charset : Charset.defaultCharset(), f.uri(), exclusionsScanner.createCharHandlerFor(f));
-    });
+    }, buildDependencyInputFiles(inputFile));
     defaultInputFile.setType(inputFile.isTest() ? Type.TEST : Type.MAIN);
     var fileLanguage = inputFile.language();
     if (fileLanguage != null) {
@@ -61,6 +64,30 @@ public class InputFileBuilder {
     }
 
     return defaultInputFile;
+  }
+
+  private List<InputFile> buildDependencyInputFiles(ClientInputFile inputFile) {
+    List<ClientInputFile> dependencyFiles = inputFile.getDependencyFiles();
+    if (dependencyFiles == null) return null;
+
+    List<InputFile> result = new LinkedList<>();
+    for (var dependencyFile : dependencyFiles) {
+      result.add(toSonarLintInputFile(dependencyFile, inputFile));
+    }
+    return result;
+  }
+
+  private SonarLintInputFile toSonarLintInputFile(ClientInputFile dependencyFile, ClientInputFile parentFile) {
+    return new SonarLintInputFile(dependencyFile, f -> {
+      LOG.debug("Initializing metadata of dependency file {} for {}", f.uri(), parentFile.uri());
+      try {
+        var charset = f.charset();
+        return fileMetadata.readMetadata(f.inputStream(), charset != null ? charset : Charset.defaultCharset(),
+                  f.uri(), exclusionsScanner.createCharHandlerFor(f));
+      } catch (IOException e) {
+        throw new IllegalStateException("Failed to open stream for dependency file: " + f.uri(), e);
+      }
+    });
   }
 
 }

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
@@ -23,13 +23,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonarsource.sonarlint.core.analysis.api.ClientInputFile;
 import org.sonarsource.sonarlint.core.analysis.container.analysis.issue.ignore.scanner.IssueExclusionsLoader;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
+import org.springframework.util.CollectionUtils;
 
 public class InputFileBuilder {
   private static final SonarLintLogger LOG = SonarLintLogger.get();
@@ -67,10 +67,14 @@ public class InputFileBuilder {
     return defaultInputFile;
   }
 
-  private List<InputFile> buildReferenceInputFiles(ClientInputFile inputFile) {
-    return Optional.ofNullable(inputFile.getReferenceFiles()).map(referenceFiles -> referenceFiles.stream()
-            .<InputFile>map(referenceFile -> toSonarLintInputFile(referenceFile, inputFile))
-            .collect(Collectors.toList())).orElse(null);
+  public List<InputFile> buildReferenceInputFiles(ClientInputFile inputFile) {
+    if (CollectionUtils.isEmpty(inputFile.getReferenceFiles())) {
+      return null;
+    } else {
+      return inputFile.getReferenceFiles().stream()
+              .<InputFile>map(referenceFile -> toSonarLintInputFile(referenceFile, inputFile))
+              .collect(Collectors.toList());
+    }
   }
 
   private SonarLintInputFile toSonarLintInputFile(ClientInputFile referenceFile, ClientInputFile parentFile) {

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
@@ -67,7 +67,7 @@ public class InputFileBuilder {
   }
 
   private List<InputFile> buildDependencyInputFiles(ClientInputFile inputFile) {
-    List<ClientInputFile> dependencyFiles = inputFile.getDependencyFiles();
+    List<ClientInputFile> dependencyFiles = inputFile.getReferenceFiles();
     if (dependencyFiles == null) return null;
 
     List<InputFile> result = new LinkedList<>();

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
@@ -22,8 +22,9 @@ package org.sonarsource.sonarlint.core.analysis.container.analysis.filesystem;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonarsource.sonarlint.core.analysis.api.ClientInputFile;
@@ -67,14 +68,9 @@ public class InputFileBuilder {
   }
 
   private List<InputFile> buildReferenceInputFiles(ClientInputFile inputFile) {
-    List<ClientInputFile> referenceFiles = inputFile.getReferenceFiles();
-    if (referenceFiles == null) return null;
-
-    List<InputFile> result = new LinkedList<>();
-    for (var referenceFile : referenceFiles) {
-      result.add(toSonarLintInputFile(referenceFile, inputFile));
-    }
-    return result;
+    return Optional.ofNullable(inputFile.getReferenceFiles()).map(referenceFiles -> referenceFiles.stream()
+            .<InputFile>map(referenceFile -> toSonarLintInputFile(referenceFile, inputFile))
+            .collect(Collectors.toList())).orElse(null);
   }
 
   private SonarLintInputFile toSonarLintInputFile(ClientInputFile referenceFile, ClientInputFile parentFile) {

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
@@ -67,7 +67,7 @@ public class InputFileBuilder {
     return defaultInputFile;
   }
 
-  public List<InputFile> buildReferenceInputFiles(ClientInputFile inputFile) {
+  private List<InputFile> buildReferenceInputFiles(ClientInputFile inputFile) {
     if (CollectionUtils.isEmpty(inputFile.getReferenceFiles())) {
       return null;
     } else {

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputFile.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputFile.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.CheckForNull;
@@ -53,11 +54,17 @@ public class SonarLintInputFile implements InputFile {
   private boolean ignoreAllIssues;
   private final Set<Integer> noSonarLines = new HashSet<>();
   private Collection<int[]> ignoreIssuesOnlineRanges;
+  private List<InputFile> dependencyInputFiles;
 
   public SonarLintInputFile(ClientInputFile clientInputFile, Function<SonarLintInputFile, Metadata> metadataGenerator) {
     this.clientInputFile = clientInputFile;
     this.metadataGenerator = metadataGenerator;
     this.relativePath = PathUtils.sanitize(clientInputFile.relativePath());
+  }
+
+  public SonarLintInputFile(ClientInputFile clientInputFile, Function<SonarLintInputFile, Metadata> metadataGenerator,List<InputFile> dependencyInputFiles) {
+    this(clientInputFile,metadataGenerator);
+    this.dependencyInputFiles = dependencyInputFiles;
   }
 
   public void checkMetadata() {
@@ -288,4 +295,8 @@ public class SonarLintInputFile implements InputFile {
     return ignoreIssuesOnlineRanges.stream().anyMatch(r -> r[0] <= line && line <= r[1]);
   }
 
+  @Override
+  public List<InputFile> getDependencyFiles() {
+    return dependencyInputFiles;
+  }
 }

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputFile.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputFile.java
@@ -54,7 +54,7 @@ public class SonarLintInputFile implements InputFile {
   private boolean ignoreAllIssues;
   private final Set<Integer> noSonarLines = new HashSet<>();
   private Collection<int[]> ignoreIssuesOnlineRanges;
-  private List<InputFile> dependencyInputFiles;
+  private List<InputFile> referenceFiles;
 
   public SonarLintInputFile(ClientInputFile clientInputFile, Function<SonarLintInputFile, Metadata> metadataGenerator) {
     this.clientInputFile = clientInputFile;
@@ -62,9 +62,9 @@ public class SonarLintInputFile implements InputFile {
     this.relativePath = PathUtils.sanitize(clientInputFile.relativePath());
   }
 
-  public SonarLintInputFile(ClientInputFile clientInputFile, Function<SonarLintInputFile, Metadata> metadataGenerator,List<InputFile> dependencyInputFiles) {
+  public SonarLintInputFile(ClientInputFile clientInputFile, Function<SonarLintInputFile, Metadata> metadataGenerator,List<InputFile> referenceFiles) {
     this(clientInputFile,metadataGenerator);
-    this.dependencyInputFiles = dependencyInputFiles;
+    this.referenceFiles = referenceFiles;
   }
 
   public void checkMetadata() {
@@ -296,7 +296,7 @@ public class SonarLintInputFile implements InputFile {
   }
 
   @Override
-  public List<InputFile> getDependencyFiles() {
-    return dependencyInputFiles;
+  public List<InputFile> getReferenceFiles() {
+    return referenceFiles;
   }
 }

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
@@ -32,6 +31,7 @@ import org.sonarsource.sonarlint.core.analysis.container.analysis.filesystem.Fil
 import org.sonarsource.sonarlint.core.analysis.container.analysis.filesystem.LanguageDetection;
 import org.sonarsource.sonarlint.core.analysis.container.analysis.filesystem.SonarLintInputFile;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
+import org.springframework.util.CollectionUtils;
 
 public class ModuleInputFileBuilder {
   private static final SonarLintLogger LOG = SonarLintLogger.get();
@@ -68,9 +68,13 @@ public class ModuleInputFileBuilder {
   }
 
   public List<InputFile> buildReferenceInputFiles(ClientInputFile inputFile) {
-    return Optional.ofNullable(inputFile.getReferenceFiles()).map(referenceFiles -> referenceFiles.stream()
-            .<InputFile>map(referenceFile -> toSonarLintInputFile(referenceFile, inputFile))
-            .collect(Collectors.toList())).orElse(null);
+    if (CollectionUtils.isEmpty(inputFile.getReferenceFiles())) {
+      return null;
+    } else {
+      return inputFile.getReferenceFiles().stream()
+               .<InputFile>map(referenceFile -> toSonarLintInputFile(referenceFile, inputFile))
+               .collect(Collectors.toList());
+    }
   }
 
   private SonarLintInputFile toSonarLintInputFile(ClientInputFile referenceFile, ClientInputFile parentFile) {

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
@@ -22,8 +22,9 @@ package org.sonarsource.sonarlint.core.analysis.container.module;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonarsource.sonarlint.core.analysis.api.ClientInputFile;
@@ -67,14 +68,9 @@ public class ModuleInputFileBuilder {
   }
 
   public List<InputFile> buildReferenceInputFiles(ClientInputFile inputFile) {
-    List<ClientInputFile> referenceFiles = inputFile.getReferenceFiles();
-    if (referenceFiles == null) return null;
-
-    List<InputFile> result = new LinkedList<>();
-    for (var referenceFile : referenceFiles) {
-      result.add(toSonarLintInputFile(referenceFile, inputFile));
-    }
-    return result;
+    return Optional.ofNullable(inputFile.getReferenceFiles()).map(referenceFiles -> referenceFiles.stream()
+            .<InputFile>map(referenceFile -> toSonarLintInputFile(referenceFile, inputFile))
+            .collect(Collectors.toList())).orElse(null);
   }
 
   private SonarLintInputFile toSonarLintInputFile(ClientInputFile referenceFile, ClientInputFile parentFile) {

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
@@ -67,7 +67,7 @@ public class ModuleInputFileBuilder {
   }
 
   public List<InputFile> buildDependencyInputFiles(ClientInputFile inputFile) {
-    List<ClientInputFile> dependencyFiles = inputFile.getDependencyFiles();
+    List<ClientInputFile> dependencyFiles = inputFile.getReferenceFiles();
     if (dependencyFiles == null) return null;
 
     List<InputFile> result = new LinkedList<>();

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
@@ -53,7 +53,7 @@ public class ModuleInputFileBuilder {
         throw new IllegalStateException("Failed to open a stream on file: " + f.uri(), e);
       }
       return fileMetadata.readMetadata(stream, charset != null ? charset : Charset.defaultCharset(), f.uri(), null);
-    }, buildDependencyInputFiles(inputFile));
+    }, buildReferenceInputFiles(inputFile));
     defaultInputFile.setType(inputFile.isTest() ? Type.TEST : Type.MAIN);
     var fileLanguage = inputFile.language();
     if (fileLanguage != null) {
@@ -66,26 +66,26 @@ public class ModuleInputFileBuilder {
     return defaultInputFile;
   }
 
-  public List<InputFile> buildDependencyInputFiles(ClientInputFile inputFile) {
-    List<ClientInputFile> dependencyFiles = inputFile.getReferenceFiles();
-    if (dependencyFiles == null) return null;
+  public List<InputFile> buildReferenceInputFiles(ClientInputFile inputFile) {
+    List<ClientInputFile> referenceFiles = inputFile.getReferenceFiles();
+    if (referenceFiles == null) return null;
 
     List<InputFile> result = new LinkedList<>();
-    for (var dependencyFile : dependencyFiles) {
-      result.add(toSonarLintInputFile(dependencyFile, inputFile));
+    for (var referenceFile : referenceFiles) {
+      result.add(toSonarLintInputFile(referenceFile, inputFile));
     }
     return result;
   }
 
-  private SonarLintInputFile toSonarLintInputFile(ClientInputFile dependencyFile, ClientInputFile parentFile) {
-    return new SonarLintInputFile(dependencyFile, f -> {
-      LOG.debug("Initializing metadata of dependency file {} for {}", f.uri(), parentFile.uri());
+  private SonarLintInputFile toSonarLintInputFile(ClientInputFile referenceFile, ClientInputFile parentFile) {
+    return new SonarLintInputFile(referenceFile, f -> {
+      LOG.debug("Initializing metadata of Reference file {} for {}", f.uri(), parentFile.uri());
       try {
         var charset = f.charset();
         return fileMetadata.readMetadata(f.inputStream(), charset != null ? charset : Charset.defaultCharset(),
                   f.uri(), null);
       } catch (IOException e) {
-        throw new IllegalStateException("Failed to open stream for dependency file: " + f.uri(), e);
+        throw new IllegalStateException("Failed to open stream for reference file: " + f.uri(), e);
       }
     }, null);
   }

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
@@ -67,7 +67,7 @@ public class ModuleInputFileBuilder {
     return defaultInputFile;
   }
 
-  public List<InputFile> buildReferenceInputFiles(ClientInputFile inputFile) {
+  private List<InputFile> buildReferenceInputFiles(ClientInputFile inputFile) {
     if (CollectionUtils.isEmpty(inputFile.getReferenceFiles())) {
       return null;
     } else {

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
@@ -22,6 +22,9 @@ package org.sonarsource.sonarlint.core.analysis.container.module;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.LinkedList;
+import java.util.List;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonarsource.sonarlint.core.analysis.api.ClientInputFile;
 import org.sonarsource.sonarlint.core.analysis.container.analysis.filesystem.FileMetadata;
@@ -50,7 +53,7 @@ public class ModuleInputFileBuilder {
         throw new IllegalStateException("Failed to open a stream on file: " + f.uri(), e);
       }
       return fileMetadata.readMetadata(stream, charset != null ? charset : Charset.defaultCharset(), f.uri(), null);
-    });
+    }, buildDependencyInputFiles(inputFile));
     defaultInputFile.setType(inputFile.isTest() ? Type.TEST : Type.MAIN);
     var fileLanguage = inputFile.language();
     if (fileLanguage != null) {
@@ -61,6 +64,30 @@ public class ModuleInputFileBuilder {
     }
 
     return defaultInputFile;
+  }
+
+  public List<InputFile> buildDependencyInputFiles(ClientInputFile inputFile) {
+    List<ClientInputFile> dependencyFiles = inputFile.getDependencyFiles();
+    if (dependencyFiles == null) return null;
+
+    List<InputFile> result = new LinkedList<>();
+    for (var dependencyFile : dependencyFiles) {
+      result.add(toSonarLintInputFile(dependencyFile, inputFile));
+    }
+    return result;
+  }
+
+  private SonarLintInputFile toSonarLintInputFile(ClientInputFile dependencyFile, ClientInputFile parentFile) {
+    return new SonarLintInputFile(dependencyFile, f -> {
+      LOG.debug("Initializing metadata of dependency file {} for {}", f.uri(), parentFile.uri());
+      try {
+        var charset = f.charset();
+        return fileMetadata.readMetadata(f.inputStream(), charset != null ? charset : Charset.defaultCharset(),
+                  f.uri(), null);
+      } catch (IOException e) {
+        throw new IllegalStateException("Failed to open stream for dependency file: " + f.uri(), e);
+      }
+    }, null);
   }
 
 }

--- a/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
@@ -588,6 +588,15 @@ public final class ConnectedSonarLintEngineImpl extends AbstractSonarLintEngine 
     return CrossFileAnalysisMode.isActive(analyzerConfiguration);
   }
 
+  @Override
+  public String  getAvailableCrossFileAnalysisRuleKey(ProjectBinding projectBinding) {
+    var analyzerConfiguration = loadAnalyzerConfiguration(projectBinding);
+    if (analyzerConfiguration == null) {
+      return "";
+    }
+    return  CrossFileAnalysisMode.getAvailableCrossFileAnalysisRuleKey(analyzerConfiguration);
+  }
+
   private AnalyzerConfiguration loadAnalyzerConfiguration(ProjectBinding projectBinding) {
     try {
       return serverConnection.getAnalyzerConfiguration(projectBinding.projectKey());
@@ -601,11 +610,20 @@ public final class ConnectedSonarLintEngineImpl extends AbstractSonarLintEngine 
 
     private static final String ENABLED_SETTING_KEY = "codescan.ide.crossFileAnalysis";
     private static final String LANGUAGE_KEY = "sf";
-    private static final Set<String> CROSS_FILE_RULE_KEYS = Set.of("sf:AvoidSoqlInLoops","sf:UnescapedOutput","sf:ResourceInjection","sf:ServerSideRequestForgery");
+    private static final List<String> CROSS_FILE_RULE_KEYS = List.of("sf:AvoidSoqlInLoops","sf:UnescapedOutput","sf:ResourceInjection","sf:ServerSideRequestForgery");
     private CrossFileAnalysisMode() {}
 
     private static boolean isActive(AnalyzerConfiguration analyzerConfiguration) {
       return isEnabled(analyzerConfiguration) && areCrossFileRulesAvailable(analyzerConfiguration, LANGUAGE_KEY);
+    }
+
+    private static String getAvailableCrossFileAnalysisRuleKey(AnalyzerConfiguration analyzerConfiguration) {
+      if (isActive(analyzerConfiguration)) {
+        return CROSS_FILE_RULE_KEYS.stream()
+                .filter(analyzerConfiguration.getRuleSetByLanguageKey().get(LANGUAGE_KEY).getRulesByKey()::containsKey)
+                .findFirst().orElse("");
+      }
+      return "";
     }
 
     private static boolean isEnabled(AnalyzerConfiguration analyzerConfiguration) {

--- a/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
@@ -577,4 +577,68 @@ public final class ConnectedSonarLintEngineImpl extends AbstractSonarLintEngine 
 
   }
 
+  @Override
+  public boolean checkIfCrossFileAnalysisIsEnabled(ProjectBinding projectBinding) {
+    var analyzerConfiguration = loadAnalyzerConfiguration(projectBinding);
+    if (analyzerConfiguration == null) {
+      return false;
+    }
+
+    return CrossFileAnalysisMode.isActive(analyzerConfiguration);
+  }
+
+  private AnalyzerConfiguration loadAnalyzerConfiguration(ProjectBinding projectBinding) {
+    try {
+      return serverConnection.getAnalyzerConfiguration(projectBinding.projectKey());
+    } catch (StorageException e) {
+      LOG.debug("Unable to read analyzer configuration from local storage", e);
+      return null;
+    }
+  }
+
+  private static final class CrossFileAnalysisMode {
+
+    private static final String ENABLED_SETTING_KEY = "codescan.ide.crossFileAnalysis";
+    private static final String LANGUAGE_KEY = "sf";
+    private static final Set<String> CROSS_FILE_RULE_KEYS = Set.of("sf:AvoidSoqlInLoops");
+    private CrossFileAnalysisMode() {}
+
+    private static boolean isActive(AnalyzerConfiguration analyzerConfiguration) {
+      return isEnabled(analyzerConfiguration) && areCrossFileRulesAvailable(analyzerConfiguration, LANGUAGE_KEY);
+    }
+
+    private static boolean isEnabled(AnalyzerConfiguration analyzerConfiguration) {
+      var settings = analyzerConfiguration.getSettings();
+      if (settings == null) {
+        return false;
+      }
+
+      var allSettings = settings.getAll();
+      if (allSettings == null || allSettings.isEmpty() || !allSettings.containsKey(ENABLED_SETTING_KEY)) {
+        return false;
+      }
+
+      return Boolean.parseBoolean(allSettings.get(ENABLED_SETTING_KEY));
+    }
+
+    private static boolean areCrossFileRulesAvailable(AnalyzerConfiguration analyzerConfiguration, String languageKey) {
+      var ruleSetsByLanguageKey = analyzerConfiguration.getRuleSetByLanguageKey();
+      if (ruleSetsByLanguageKey == null || ruleSetsByLanguageKey.isEmpty()) {
+        // Can happen before the first synchronization
+        return false;
+      }
+
+      var ruleSet = ruleSetsByLanguageKey.get(languageKey);
+      if (ruleSet == null) {
+        return false;
+      }
+
+      var availableRulesByKey = ruleSet.getRulesByKey();
+      if (availableRulesByKey == null || availableRulesByKey.isEmpty()) {
+        return false;
+      }
+
+     return CROSS_FILE_RULE_KEYS.stream().anyMatch(availableRulesByKey::containsKey);
+    }
+  }
 }

--- a/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
@@ -600,7 +600,7 @@ public final class ConnectedSonarLintEngineImpl extends AbstractSonarLintEngine 
 
     private static final String ENABLED_SETTING_KEY = "codescan.ide.crossFileAnalysis";
     private static final String LANGUAGE_KEY = "sf";
-    private static final Set<String> CROSS_FILE_RULE_KEYS = Set.of("sf:AvoidSoqlInLoops");
+    private static final Set<String> CROSS_FILE_RULE_KEYS = Set.of("sf:AvoidSoqlInLoops","sf:UnescapedOutput","sf:ResourceInjection","sf:ServerSideRequestForgery");
     private CrossFileAnalysisMode() {}
 
     private static boolean isActive(AnalyzerConfiguration analyzerConfiguration) {

--- a/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
@@ -82,6 +82,7 @@ import org.sonarsource.sonarlint.core.serverconnection.ServerConnection;
 import org.sonarsource.sonarlint.core.serverconnection.issues.ServerIssue;
 import org.sonarsource.sonarlint.core.serverconnection.issues.ServerTaintIssue;
 import org.sonarsource.sonarlint.core.serverconnection.storage.StorageException;
+import org.springframework.util.CollectionUtils;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
@@ -614,7 +615,7 @@ public final class ConnectedSonarLintEngineImpl extends AbstractSonarLintEngine 
       }
 
       var allSettings = settings.getAll();
-      if (allSettings == null || allSettings.isEmpty() || !allSettings.containsKey(ENABLED_SETTING_KEY)) {
+      if (CollectionUtils.isEmpty(allSettings) || !allSettings.containsKey(ENABLED_SETTING_KEY)) {
         return false;
       }
 
@@ -623,7 +624,7 @@ public final class ConnectedSonarLintEngineImpl extends AbstractSonarLintEngine 
 
     private static boolean areCrossFileRulesAvailable(AnalyzerConfiguration analyzerConfiguration, String languageKey) {
       var ruleSetsByLanguageKey = analyzerConfiguration.getRuleSetByLanguageKey();
-      if (ruleSetsByLanguageKey == null || ruleSetsByLanguageKey.isEmpty()) {
+      if (CollectionUtils.isEmpty(ruleSetsByLanguageKey)) {
         // Can happen before the first synchronization
         return false;
       }
@@ -634,7 +635,7 @@ public final class ConnectedSonarLintEngineImpl extends AbstractSonarLintEngine 
       }
 
       var availableRulesByKey = ruleSet.getRulesByKey();
-      if (availableRulesByKey == null || availableRulesByKey.isEmpty()) {
+      if (CollectionUtils.isEmpty(availableRulesByKey)) {
         return false;
       }
 

--- a/core/src/main/java/org/sonarsource/sonarlint/core/client/api/connected/ConnectedSonarLintEngine.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/client/api/connected/ConnectedSonarLintEngine.java
@@ -216,4 +216,6 @@ public interface ConnectedSonarLintEngine extends SonarLintEngine {
   void subscribeForEvents(EndpointParams endpoint, HttpClient client, Set<String> projectKeys, Consumer<ServerEvent> eventConsumer, @Nullable ClientLogOutput clientLogOutput);
 
   boolean checkIfCrossFileAnalysisIsEnabled(ProjectBinding projectBinding);
+
+  String getAvailableCrossFileAnalysisRuleKey(ProjectBinding projectBinding);
 }

--- a/core/src/main/java/org/sonarsource/sonarlint/core/client/api/connected/ConnectedSonarLintEngine.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/client/api/connected/ConnectedSonarLintEngine.java
@@ -215,4 +215,5 @@ public interface ConnectedSonarLintEngine extends SonarLintEngine {
 
   void subscribeForEvents(EndpointParams endpoint, HttpClient client, Set<String> projectKeys, Consumer<ServerEvent> eventConsumer, @Nullable ClientLogOutput clientLogOutput);
 
+  boolean checkIfCrossFileAnalysisIsEnabled(ProjectBinding projectBinding);
 }


### PR DESCRIPTION
**As discussed with the product team, cross-file analysis may impact performance and memory usage 
while running.** 



Currently, the IDE extension performs file-wise analysis, meaning only the file that is opened or modified gets analyzed. This approach causes inaccurate or missed violations for rules that require context across multiple files (e.g., AvoidSOQLInLoops, where validation may depend on logic spread across classes or triggers).

To address this limitation:

Introduce a Project Setting in the CodeScan apllication:

Cross-File Analysis Control (default: Disabled to preserve performance).

IDE Cross file analysis-20260303-064801.png
 

Identify and tag all rules that require cross-file or full-project traversal.

If Cross-File Analysis is Enabled:

The engine should traverse all relevant files when evaluating tagged rules.

However, only violations related to the currently opened file should be displayed in the IDE.

Violations found in other files during traversal should not be shown in the IDE panel.

Scan Optimization Rules:

If a class file is opened → analyze all class files first, then remaining files if needed.

If cross-file-required rules are not present in the active Quality Profile, skip full project traversal entirely.

Ensure traversal is rule-aware and profile-aware to prevent unnecessary scanning.

Hypothesis
If cross-file analysis is made configurable and rule-aware, the IDE extension will:

Provide more accurate detection for interdependent rules.

Maintain performance efficiency by scanning only when required.

Prevent developer distraction by limiting displayed violations to the active file.

Reduce unnecessary full-project scans when cross-file rules are not active in the Quality Profile.

Value / Purpose
Improved Rule Accuracy – Enables correct evaluation of cross-dependent rules like AvoidSOQLInLoops.

Developer Experience – Keeps IDE feedback focused on the current file, avoiding noise.

Performance Optimization – Conditional traversal reduces unnecessary scans.

Acceptance Criteria


Introduce a Project Setting in the CodeScan apllication:

Cross-File Analysis Control (default: Disabled to preserve performance).

IDE Cross file analysis-20260303-064801.png
Add Note: “Note: After enabling or disabling this setting, CodeScan project bindings must be updated again in the IDE.“

Identify and tag all rules that require cross-file or full-project traversal.

If Cross-File Analysis is Enabled:

The engine should traverse all relevant files when evaluating tagged rules.

However, only violations related to the currently opened file should be displayed in the IDE.

Violations found in other files during traversal should not be shown in the IDE panel.

Scan Optimization Rules:

If a class file is opened → analyze all class files first, then remaining files if needed.

If cross-file-required rules are not present in the active Quality Profile, skip full project traversal entirely.

Ensure traversal is rule-aware and profile-aware to prevent unnecessary scanning.